### PR TITLE
Fixing documentation for byte_f.

### DIFF
--- a/src/Data/Byte.idr
+++ b/src/Data/Byte.idr
@@ -22,7 +22,7 @@ public export %inline
 byte_a : Bits8
 byte_a = 97
 
-||| ASCII code of 'a'
+||| ASCII code of 'f'
 public export %inline
 byte_f : Bits8
 byte_f = 102


### PR DESCRIPTION
This PR fixes the documentation for `byte_f`, correcting from `ASCII code of 'a'` to `ASCII code of 'f'`.