### PR TITLE
Adding more byte definitions.

### DIFF
--- a/src/Data/Byte.idr
+++ b/src/Data/Byte.idr
@@ -7,10 +7,45 @@ public export %inline
 byte_0 : Bits8
 byte_0 = 48
 
+||| ASCII code of '1'
+public export %inline
+byte_1 : Bits8
+byte_1 = 49
+
+||| ASCII code of '2'
+public export %inline
+byte_2 : Bits8
+byte_2 = 50
+
+||| ASCII code of '3'
+public export %inline
+byte_3 : Bits8
+byte_3 = 51
+
+||| ASCII code of '4'
+public export %inline
+byte_4 : Bits8
+byte_4 = 52
+
+||| ASCII code of '5'
+public export %inline
+byte_5 : Bits8
+byte_5 = 53
+
+||| ASCII code of '6'
+public export %inline
+byte_6 : Bits8
+byte_6 = 54
+
 ||| ASCII code of '7'
 public export %inline
 byte_7 : Bits8
 byte_7 = 55
+
+||| ASCII code of '8'
+public export %inline
+byte_8 : Bits8
+byte_8 = 56
 
 ||| ASCII code of '9'
 public export %inline
@@ -22,10 +57,125 @@ public export %inline
 byte_a : Bits8
 byte_a = 97
 
+||| ASCII code of 'b'
+public export %inline
+byte_b : Bits8
+byte_b = 98
+
+||| ASCII code of 'c'
+public export %inline
+byte_c : Bits8
+byte_c = 99
+
+||| ASCII code of 'd'
+public export %inline
+byte_d : Bits8
+byte_d = 100
+
+||| ASCII code of 'e'
+public export %inline
+byte_e : Bits8
+byte_e = 101
+
 ||| ASCII code of 'f'
 public export %inline
 byte_f : Bits8
 byte_f = 102
+
+||| ASCII code of 'g'
+public export %inline
+byte_g : Bits8
+byte_g = 103
+
+||| ASCII code of 'h'
+public export %inline
+byte_h : Bits8
+byte_h = 104
+
+||| ASCII code of 'i'
+public export %inline
+byte_i : Bits8
+byte_i = 105
+
+||| ASCII code of 'j'
+public export %inline
+byte_j : Bits8
+byte_j = 106
+
+||| ASCII code of 'k'
+public export %inline
+byte_k : Bits8
+byte_k = 107
+
+||| ASCII code of 'l'
+public export %inline
+byte_l : Bits8
+byte_l = 108
+
+||| ASCII code of 'm'
+public export %inline
+byte_m : Bits8
+byte_m = 109
+
+||| ASCII code of 'n'
+public export %inline
+byte_n : Bits8
+byte_n = 110
+
+||| ASCII code of 'o'
+public export %inline
+byte_o : Bits8
+byte_o = 111
+
+||| ASCII code of 'p'
+public export %inline
+byte_p : Bits8
+byte_p = 112
+
+||| ASCII code of 'q'
+public export %inline
+byte_q : Bits8
+byte_q = 113
+
+||| ASCII code of 'r'
+public export %inline
+byte_r : Bits8
+byte_r = 114
+
+||| ASCII code of 's'
+public export %inline
+byte_s : Bits8
+byte_s = 115
+
+||| ASCII code of 't'
+public export %inline
+byte_t : Bits8
+byte_t = 116
+
+||| ASCII code of 'u'
+public export %inline
+byte_u : Bits8
+byte_u = 117
+
+||| ASCII code of 'v'
+public export %inline
+byte_v : Bits8
+byte_v = 118
+
+||| ASCII code of 'w'
+public export %inline
+byte_w : Bits8
+byte_w = 119
+
+||| ASCII code of 'x'
+public export %inline
+byte_x : Bits8
+byte_x = 120
+
+||| ASCII code of 'y'
+public export %inline
+byte_y : Bits8
+byte_y = 121
 
 ||| ASCII code of 'z'
 public export %inline
@@ -36,6 +186,126 @@ byte_z = 122
 public export %inline
 byte_A : Bits8
 byte_A = 65
+
+||| ASCII code of 'B'
+public export %inline
+byte_B : Bits8
+byte_B = 66
+
+||| ASCII code of 'C'
+public export %inline
+byte_C : Bits8
+byte_C = 67
+
+||| ASCII code of 'D'
+public export %inline
+byte_D : Bits8
+byte_D = 68
+
+||| ASCII code of 'E'
+public export %inline
+byte_E : Bits8
+byte_E = 69
+
+||| ASCII code of 'F'
+public export %inline
+byte_F : Bits8
+byte_F = 70
+
+||| ASCII code of 'G'
+public export %inline
+byte_G : Bits8
+byte_G = 71
+
+||| ASCII code of 'H'
+public export %inline
+byte_H : Bits8
+byte_H = 72
+
+||| ASCII code of 'I'
+public export %inline
+byte_I : Bits8
+byte_I = 73
+
+||| ASCII code of 'J'
+public export %inline
+byte_J : Bits8
+byte_J = 74
+
+||| ASCII code of 'K'
+public export %inline
+byte_K : Bits8
+byte_K = 75
+
+||| ASCII code of 'L'
+public export %inline
+byte_L : Bits8
+byte_L = 76
+
+||| ASCII code of 'M'
+public export %inline
+byte_M : Bits8
+byte_M = 77
+
+||| ASCII code of 'N'
+public export %inline
+byte_N : Bits8
+byte_N = 78
+
+||| ASCII code of 'O'
+public export %inline
+byte_O : Bits8
+byte_O = 79
+
+||| ASCII code of 'P'
+public export %inline
+byte_P : Bits8
+byte_P = 80
+
+||| ASCII code of 'Q'
+public export %inline
+byte_Q : Bits8
+byte_Q = 81
+
+||| ASCII code of 'R'
+public export %inline
+byte_R : Bits8
+byte_R = 82
+
+||| ASCII code of 'S'
+public export %inline
+byte_S : Bits8
+byte_S = 83
+
+||| ASCII code of 'T'
+public export %inline
+byte_T : Bits8
+byte_T = 84
+
+||| ASCII code of 'U'
+public export %inline
+byte_U : Bits8
+byte_U = 85
+
+||| ASCII code of 'V'
+public export %inline
+byte_V : Bits8
+byte_V = 86
+
+||| ASCII code of 'W'
+public export %inline
+byte_W : Bits8
+byte_W = 87
+
+||| ASCII code of 'X'
+public export %inline
+byte_X : Bits8
+byte_X = 88
+
+||| ASCII code of 'Y'
+public export %inline
+byte_Y : Bits8
+byte_Y = 89
 
 ||| ASCII code of 'Z'
 public export %inline


### PR DESCRIPTION
This PR seeks to add more `byte` definitions to fill in the gaps for `0-9`, `a-z` and `A-Z`.